### PR TITLE
Upgrade to focal; Use github repositories; Build the latest OpenVAS V20(!!)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,98 +1,87 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 MAINTAINER danielpops@gmail.com
 
 RUN apt-get update > /dev/null \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        alien \
-        autoconf \
         bison \
-        clang \
         cmake \
         curl \
         doxygen \
-        flex \
         g++ \
         gcc \
-        gcc-mingw-w64 \
-        git \
-        gnutls-bin \
-        heimdal-dev \
-        heimdal-multidev \
+        git-core \
+        graphviz \
+        libical-dev \
+        libldap2-dev \
+        libgcrypt20-dev \
         libglib2.0-dev \
-        libgnutls-dev \
-        libgpgme11-dev \
+        libgnutls28-dev \
+        libgpgme-dev \
         libhiredis-dev \
         libksba-dev \
-        libldap2-dev \
         libmicrohttpd-dev \
         libpcap-dev \
-        libpopt-dev \
+        libpq-dev \
         libsnmp-dev \
-        libsqlite3-dev \
-        libssh-dev \
+        libssh-gcrypt-dev \
         libxml2-dev \
-        libxslt-dev \
-        nsis \
-        openssh-client \
-        openssl \
-        perl-base \
+        make \
+        nmap \
         pkg-config \
-        python-lxml \
-        python-pip \
+        postgresql-server-dev-all \
         redis-server \
-        rpm \
         rsync \
-        sqlfairy \
-        sqlite3 \
-        tcl \
-        texlive-latex-extra \
-        texlive-fonts-recommended \
+        sudo \
         uuid-dev \
         vim \
-        wget \
         xmltoman \
-        xsltproc \
-            > /dev/null \
-    && apt-get clean
+        xsltproc
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update > /dev/null \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        nodejs \
+        yarn
 
-# Install nmap from source
-# Openvas recommends an ancient version
-ENV NMAP_VERSION=nmap-7.60
-WORKDIR /nmap/
-RUN curl -O https://nmap.org/dist/$NMAP_VERSION.tar.bz2 \
-    && bzip2 -cd $NMAP_VERSION.tar.bz2 | tar xvf - > /dev/null \
-    && cd /nmap/$NMAP_VERSION/ \
-    && ./configure --prefix=/ > /dev/null \
-    && make > /dev/null \
-    && make install \
-    && rm -rf /nmap/
+RUN apt-get install -y xml-twig-tools
 
 WORKDIR /openvas
-
-RUN for i in openvas-libraries-9.0.1,2420 openvas-scanner-5.1.1,2423 openvas-manager-7.0.2,2448 greenbone-security-assistant-7.0.2,2429 openvas-cli-1.4.5,2397; do \
-        IFS=","; \
-        set -- $i; \
-        wget http://wald.intevation.org/frs/download.php/$2/$1.tar.gz; \
-        tar xfvz $1.tar.gz > /dev/null; \
-        cd $1; \
-        cmake . > /dev/null; \
-        make install > /dev/null; \
+RUN for i in gvm-libs gvmd gsa openvas; do \
+        git clone https://github.com/greenbone/$i --depth=1; \
+        cd $i; \
+        sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
+        sed -i 's/^.*return OPENVAS_ENCAPS_TLSv13;.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
+        cmake .; \
+        make install; \
         cd ..; \
-        rm -rf $1; \
-        rm -rf $1.tar.gz; \
-        done
+        rm -rf $i; \
+    done
 
-RUN ldconfig
 
+#RUN git clone https://github.com/greenbone/gvm-libs
+#WORKDIR /openvas/gvm-libs
+#RUN cmake . && make install
+#WORKDIR /openvas
+#RUN git clone https://github.com/greenbone/gvmd
+#WORKDIR /openvas/gvmd
+#RUN cmake . && make install
+#WORKDIR /openvas
+#RUN git clone https://github.com/greenbone/gsa
+#WORKDIR /openvas/gsa
+#RUN cmake . && make install
+#WORKDIR /openvas
+#RUN git clone https://github.com/greenbone/openvas
+#WORKDIR /openvas/openvas
+## Hack to work around build errors when libgnutls does not support tls 1.3
+#RUN sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c
+#RUN sed -i 's/^.*return OPENVAS_ENCAPS_TLSv13;.*$//g' /openvas/openvas/misc/network.c
+#RUN cmake .
+#RUN make install
+RUN echo 'nobody ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/01-nobody && \
+        chown -R nobody /openvas && \
+        chown -R nobody /usr/local/var/
 ADD redis.conf /etc/redis/redis.conf
-ADD setup.sh setup.sh
-RUN chmod +x setup.sh
-
-# Takes very long
-RUN ./setup.sh
-
-ADD start.sh start.sh
-RUN chmod +x start.sh
-
-ENTRYPOINT ["/openvas/start.sh"]
+USER nobody
+#RUN greenbone-nvt-sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update > /dev/null \
         libldap2-dev \
         libgcrypt20-dev \
         libglib2.0-dev \
-        libgnutls28-dev \
         libgpgme-dev \
         libhiredis-dev \
         libksba-dev \
@@ -51,7 +50,7 @@ WORKDIR /openvas
 RUN curl -L -O https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz; \
         tar xfvz ./nettle-3.6.tar.gz; \
         cd ./nettle-3.6; \
-        ./configure; \
+        ./configure --prefix=/usr --disable-static; \
         make; \
         make check; \
         make install; \
@@ -59,16 +58,16 @@ RUN curl -L -O https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz; \
         rm -rf ./nettle-3.6;
 # Install gnutls 3.6.15
 RUN curl -L -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.15.tar.xz; \
-        tar xfvz ./gnutls-3.6.15; \
+        tar -xf ./gnutls-3.6.15.tar.xz; \
         cd ./gnutls-3.6.15; \
-        ./configure; \
+        ./configure --prefix=/usr --disable-guile --with-included-unistring; \
         make; \
         make check; \
         make install; \
         cd ..; \
         rm -rf ./gnutls-3.6.15;
 
-RUN for i in gvm-libs gvmd gsa openvas; do \
+RUN for i in gvm-libs gvmd openvas gsa; do \
         git clone https://github.com/greenbone/$i --depth=1; \
         cd $i; \
         sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN for i in gvm-libs gvmd openvas gsa; do \
         make install; \
         cd ..; \
         rm -rf $i; \
+        ldconfig; \
     done
 
 
@@ -62,4 +63,4 @@ RUN echo 'nobody ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/01-nobody && \
         chown -R nobody /usr/local/var/
 ADD redis.conf /etc/redis/redis.conf
 USER nobody
-RUN greenbone-nvt-sync
+#RUN greenbone-nvt-sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update > /dev/null \
         g++ \
         gcc \
         git-core \
+        gnutls-bin \
         graphviz \
         libical-dev \
         libldap2-dev \
@@ -46,41 +47,19 @@ RUN apt-get update > /dev/null \
         yarn
 
 WORKDIR /openvas
-# Install nettle from source
-RUN VERSION=3.5; \
-        curl -L -O https://ftp.gnu.org/gnu/nettle/nettle-${VERSION}.tar.gz; \
-        tar xfvz ./nettle-${VERSION}.tar.gz; \
-        cd ./nettle-${VERSION}; \
-        ./configure --prefix=/usr --enable-mini-gmp --disable-static; \
-        make; \
+RUN for i in gvm-libs gvmd openvas gsa; do \
+        git clone https://github.com/greenbone/$i --depth=1; \
+        cd $i; \
+        cmake .; \
         make install; \
         cd ..; \
-        rm -rf ./nettle-${VERSION};
-# Install gnutls from source
-RUN VERSION=3.6.4; \
-        curl -L -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-${VERSION}.tar.xz; \
-        tar -xf ./gnutls-${VERSION}.tar.xz; \
-        cd ./gnutls-${VERSION}; \
-        ./configure --prefix=/usr --with-included-unistring; \
-        make; \
-        make install; \
-        cd ..; \
-#        rm -rf ./gnutls-${VERSION};
-
-#RUN for i in gvm-libs gvmd openvas gsa; do \
-#        git clone https://github.com/greenbone/$i --depth=1; \
-#        cd $i; \
-#        sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
-#        sed -i 's/^.*return OPENVAS_ENCAPS_TLSv13;.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
-#        cmake .; \
-#        make install; \
-#        cd ..; \
-##        rm -rf $i; \
-#    done
+        rm -rf $i; \
+    done
 
 
-#RUN echo 'nobody ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/01-nobody && \
-#        chown -R nobody /openvas && \
-#        chown -R nobody /usr/local/var/
-#ADD redis.conf /etc/redis/redis.conf
-#USER nobody
+RUN echo 'nobody ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/01-nobody && \
+        chown -R nobody /openvas && \
+        chown -R nobody /usr/local/var/
+ADD redis.conf /etc/redis/redis.conf
+USER nobody
+RUN greenbone-nvt-sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,61 +46,41 @@ RUN apt-get update > /dev/null \
         yarn
 
 WORKDIR /openvas
-# Install nettle 3.6
-RUN curl -L -O https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz; \
-        tar xfvz ./nettle-3.6.tar.gz; \
-        cd ./nettle-3.6; \
-        ./configure --prefix=/usr --disable-static; \
+# Install nettle from source
+RUN VERSION=3.5; \
+        curl -L -O https://ftp.gnu.org/gnu/nettle/nettle-${VERSION}.tar.gz; \
+        tar xfvz ./nettle-${VERSION}.tar.gz; \
+        cd ./nettle-${VERSION}; \
+        ./configure --prefix=/usr --enable-mini-gmp --disable-static; \
         make; \
-        make check; \
         make install; \
         cd ..; \
-        rm -rf ./nettle-3.6;
-# Install gnutls 3.6.15
-RUN curl -L -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.15.tar.xz; \
-        tar -xf ./gnutls-3.6.15.tar.xz; \
-        cd ./gnutls-3.6.15; \
-        ./configure --prefix=/usr --disable-guile --with-included-unistring; \
+        rm -rf ./nettle-${VERSION};
+# Install gnutls from source
+RUN VERSION=3.6.4; \
+        curl -L -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-${VERSION}.tar.xz; \
+        tar -xf ./gnutls-${VERSION}.tar.xz; \
+        cd ./gnutls-${VERSION}; \
+        ./configure --prefix=/usr --with-included-unistring; \
         make; \
-        make check; \
         make install; \
         cd ..; \
-        rm -rf ./gnutls-3.6.15;
+#        rm -rf ./gnutls-${VERSION};
 
-RUN for i in gvm-libs gvmd openvas gsa; do \
-        git clone https://github.com/greenbone/$i --depth=1; \
-        cd $i; \
-        sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
-        sed -i 's/^.*return OPENVAS_ENCAPS_TLSv13;.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
-        cmake .; \
-        make install; \
-        cd ..; \
-        rm -rf $i; \
-    done
+#RUN for i in gvm-libs gvmd openvas gsa; do \
+#        git clone https://github.com/greenbone/$i --depth=1; \
+#        cd $i; \
+#        sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
+#        sed -i 's/^.*return OPENVAS_ENCAPS_TLSv13;.*$//g' /openvas/openvas/misc/network.c 2>&1 > /dev/null || true; \
+#        cmake .; \
+#        make install; \
+#        cd ..; \
+##        rm -rf $i; \
+#    done
 
 
-#RUN git clone https://github.com/greenbone/gvm-libs
-#WORKDIR /openvas/gvm-libs
-#RUN cmake . && make install
-#WORKDIR /openvas
-#RUN git clone https://github.com/greenbone/gvmd
-#WORKDIR /openvas/gvmd
-#RUN cmake . && make install
-#WORKDIR /openvas
-#RUN git clone https://github.com/greenbone/gsa
-#WORKDIR /openvas/gsa
-#RUN cmake . && make install
-#WORKDIR /openvas
-#RUN git clone https://github.com/greenbone/openvas
-#WORKDIR /openvas/openvas
-## Hack to work around build errors when libgnutls does not support tls 1.3
-#RUN sed -i 's/^.*GNUTLS_TLS1_3:.*$//g' /openvas/openvas/misc/network.c
-#RUN sed -i 's/^.*return OPENVAS_ENCAPS_TLSv13;.*$//g' /openvas/openvas/misc/network.c
-#RUN cmake .
-#RUN make install
-RUN echo 'nobody ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/01-nobody && \
-        chown -R nobody /openvas && \
-        chown -R nobody /usr/local/var/
-ADD redis.conf /etc/redis/redis.conf
-USER nobody
-#RUN greenbone-nvt-sync
+#RUN echo 'nobody ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/01-nobody && \
+#        chown -R nobody /openvas && \
+#        chown -R nobody /usr/local/var/
+#ADD redis.conf /etc/redis/redis.conf
+#USER nobody

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get update > /dev/null \
         make \
         nmap \
         pkg-config \
+        postgresql \
+        postgresql-contrib \
         postgresql-server-dev-all \
         redis-server \
         rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 MAINTAINER danielpops@gmail.com
 
 RUN apt-get update > /dev/null \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update > /dev/null \
         sudo \
         uuid-dev \
         vim \
+        xml-twig-tools \
         xmltoman \
         xsltproc
 
@@ -45,9 +46,28 @@ RUN apt-get update > /dev/null \
         nodejs \
         yarn
 
-RUN apt-get install -y xml-twig-tools
-
 WORKDIR /openvas
+# Install nettle 3.6
+RUN curl -L -O https://ftp.gnu.org/gnu/nettle/nettle-3.6.tar.gz; \
+        tar xfvz ./nettle-3.6.tar.gz; \
+        cd ./nettle-3.6; \
+        ./configure; \
+        make; \
+        make check; \
+        make install; \
+        cd ..; \
+        rm -rf ./nettle-3.6;
+# Install gnutls 3.6.15
+RUN curl -L -O https://www.gnupg.org/ftp/gcrypt/gnutls/v3.6/gnutls-3.6.15.tar.xz; \
+        tar xfvz ./gnutls-3.6.15; \
+        cd ./gnutls-3.6.15; \
+        ./configure; \
+        make; \
+        make check; \
+        make install; \
+        cd ..; \
+        rm -rf ./gnutls-3.6.15;
+
 RUN for i in gvm-libs gvmd gsa openvas; do \
         git clone https://github.com/greenbone/$i --depth=1; \
         cd $i; \

--- a/redis.conf
+++ b/redis.conf
@@ -1,5 +1,5 @@
-unixsocket /tmp/redis.sock
-unixsocketperm 700
+unixsocket /run/redis/redis.sock
+unixsocketperm 770
 timeout 0
 #DB = 1 + (#of parallel tasks) * (#of parallel hosts)
 databases 128

--- a/setup.sh
+++ b/setup.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-openvas-manage-certs -a -i -f
-
+# Wait 43234234732482374 years for greenbone NVTs to sync
 greenbone-nvt-sync > /dev/null
-greenbone-scapdata-sync
-greenbone-certdata-sync
 
+# Start redis
+sudo service redis-server start
 
-echo "Setting Admin user password..."
-openvasmd --create-user=admin --role=Admin
-openvasmd --user=admin --new-password=openvas
+# Update the NVTs to redis
+sudo openvas -u
+
+#echo "Setting Admin user password..."
+#openvasmd --create-user=admin --role=Admin
+#openvasmd --user=admin --new-password=openvas
 
 echo "Finished setup..."

--- a/setup.sh
+++ b/setup.sh
@@ -3,11 +3,25 @@
 # Wait 43234234732482374 years for greenbone NVTs to sync
 greenbone-nvt-sync > /dev/null
 
+# Same for scapdata and certdata, but they are "optional"
+#greenbone-scapdata-sync > /dev/null
+#greenbone-certdata-sync > /dev/null
+
 # Start redis
 sudo service redis-server start
 
 # Update the NVTs to redis
 sudo openvas -u
+
+# Set up postgres
+sudo service postgresql start
+sudo -u postgres createuser -DRS nobody
+sudo -u postgres createdb -O nobody gvmd
+sudo -u postgres psql gvmd -c 'create role dba with superuser noinherit;'
+sudo -u postgres psql gvmd -c 'grant dba to nobody;'
+
+sudo -u postgres psql gvmd -c 'create extension "uuid-ossp";'
+sudo -u postgres psql gvmd -c 'create extension "pgcrypto";'
 
 #echo "Setting Admin user password..."
 #openvasmd --create-user=admin --role=Admin


### PR DESCRIPTION
Kinda still WIP, because building and syncing takes so dang long

It's been a long time, many updates here:
- Update base image to ubuntu:focal
- Switch to use github repositories, which openvas folks have _finally_ migrated to!!
- Path updates for redis socket
- Painfully and iteratively figure out the set of packages that need to be installed
- Run the sync as nobody, which is apparently a requirement now
- Give nobody sudo capabilities

Still Pending:
- Updates to the setup and start scripts
- Actually seeing this run end-to-end
- Add comments